### PR TITLE
local dev username

### DIFF
--- a/back/.env.template
+++ b/back/.env.template
@@ -1,7 +1,11 @@
 # APPLICATION SECRET KEY
 NESOP_SECRET_KEY=
 ALLOWED_HOSTS=localhost,127.0.0.1
+
+# In production, this should be False
 DEBUG=False
+# In production, this should be empty
+LOCAL_DEBUG_USER=
 
 # PATHS
 NESOP_OP_PATH=

--- a/back/ne_sop_backend/ne_sop_backend/middleware.py
+++ b/back/ne_sop_backend/ne_sop_backend/middleware.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+from django.contrib.auth.middleware import RemoteUserMiddleware
+
+
+class RemoteSitnMiddleware(RemoteUserMiddleware):
+    """
+    Custom middleware to mimic a SSPI Auth when we dev in local
+    It will set a Remote-User header with the DEBUG_USER in settings
+    """
+    def process_request(self, request):
+        if settings.DEBUG and getattr(settings, "DEBUG_USER", None):
+            request.META[self.header] = settings.DEBUG_USER
+        super().process_request(request)

--- a/back/ne_sop_backend/ne_sop_backend/settings.py
+++ b/back/ne_sop_backend/ne_sop_backend/settings.py
@@ -30,6 +30,9 @@ SECRET_KEY = os.environ["NESOP_SECRET_KEY"]
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True if os.environ.get('DEBUG', '') == 'True' else False
 
+if DEBUG and os.environ.get('LOCAL_DEBUG_USER'):
+    DEBUG_USER = os.environ["LOCAL_DEBUG_USER"]
+
 ALLOWED_HOSTS = os.environ["ALLOWED_HOSTS"].split(",")
 
 CSRF_TRUSTED_ORIGINS = []
@@ -62,7 +65,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.auth.middleware.RemoteUserMiddleware",
+    "ne_sop_backend.middleware.RemoteSitnMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     # CORS
@@ -71,7 +74,6 @@ MIDDLEWARE = [
 ]
 
 AUTHENTICATION_BACKENDS = [
-    'django.contrib.auth.backends.ModelBackend',
     'django.contrib.auth.backends.RemoteUserBackend',
 ]
 


### PR DESCRIPTION
This PR:
- Allows us to mimic any username for localdev like it will be seen in production. For instance if `LOCAL_DEBUG_USER=` is set to `toto`, you'll see the app as toto user.
- Deletes useless ModelBackend in AUTHENTICATION_BACKENDS because RemoteUserBackend inherits from ModelBackend