### PR TITLE
avoid new user

### DIFF
--- a/back/ne_sop_backend/ne_sop_backend/middleware.py
+++ b/back/ne_sop_backend/ne_sop_backend/middleware.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib.auth.middleware import RemoteUserMiddleware
-
+from django.contrib.auth.backends import RemoteUserBackend
 
 class RemoteSitnMiddleware(RemoteUserMiddleware):
     """
@@ -11,3 +11,7 @@ class RemoteSitnMiddleware(RemoteUserMiddleware):
         if settings.DEBUG and getattr(settings, "DEBUG_USER", None):
             request.META[self.header] = settings.DEBUG_USER
         super().process_request(request)
+
+
+class RemoteSitnUserBackend(RemoteUserBackend):
+    create_unknown_user = False

--- a/back/ne_sop_backend/ne_sop_backend/settings.py
+++ b/back/ne_sop_backend/ne_sop_backend/settings.py
@@ -67,7 +67,7 @@ MIDDLEWARE = [
 ]
 
 AUTHENTICATION_BACKENDS = [
-    'django.contrib.auth.backends.RemoteUserBackend',
+    "ne_sop_backend.middleware.RemoteSitnUserBackend",
 ]
 
 ROOT_URLCONF = "ne_sop_backend.urls"


### PR DESCRIPTION
This PR configures the RemoteUserBackend so it doesn't create an user automatically